### PR TITLE
fix: iOS issue with status bar

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -732,7 +732,7 @@ static NSString* toBase64(NSData* data) {
 
 - (BOOL)prefersStatusBarHidden
 {
-    return YES;
+    return NO;
 }
 
 - (UIViewController*)childViewControllerForStatusBarHidden


### PR DESCRIPTION
It seems that, at least on iOS 13 and iPhone X and +, we have an issue
with the status bar and this plugin.

Currently, the plugin hides the status bar during the photo, and enable it
after. But the bar was not well placed and the display was broken.

By not hidding the bar we resolve this issue. It seems that the bar is hidden
byt the OS and the view for taking the photo. So no need to hide it of our own.

Tested on iPhone X iOS 13 and iPhone 7 iOS 12

![17B55BE7-4F06-4F2D-AB79-B7C2D375BEC5](https://user-images.githubusercontent.com/1107936/65513426-890c4e80-dedb-11e9-86de-ade69e93c974.png)


upstream issue: https://github.com/apache/cordova-plugin-camera/issues/507